### PR TITLE
Skip files where getMainPath fails instead of dying.

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,8 @@ func main() {
 	for _, file := range bins {
 		path, err := getMainPath(file)
 		if err != nil {
-			log.Fatal(err)
+			log.Printf("Skipping %s: %s", file, err)
+			continue
 		}
 		importPath := stripPath(path)
 		if *dry {


### PR DESCRIPTION
This makes it possible to run on a `$GOPATH/bin` where there are other kinds of files.
